### PR TITLE
[HIMIN-72] feat : 회원가입 기능 구현

### DIFF
--- a/src/main/java/com/prgrms/himin/member/api/MemberController.java
+++ b/src/main/java/com/prgrms/himin/member/api/MemberController.java
@@ -1,9 +1,16 @@
 package com.prgrms.himin.member.api;
 
+import javax.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.prgrms.himin.member.application.MemberService;
+import com.prgrms.himin.member.dto.request.MemberCreateRequest;
+import com.prgrms.himin.member.dto.response.MemberCreateResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,4 +20,9 @@ import lombok.RequiredArgsConstructor;
 public class MemberController {
 
 	private final MemberService memberService;
+
+	@PostMapping
+	public ResponseEntity<MemberCreateResponse> createMember(@Valid @RequestBody MemberCreateRequest request) {
+		return ResponseEntity.ok(memberService.createMember(request));
+	}
 }

--- a/src/main/java/com/prgrms/himin/member/api/MemberController.java
+++ b/src/main/java/com/prgrms/himin/member/api/MemberController.java
@@ -16,12 +16,12 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/members")
+@RequestMapping("/api")
 public class MemberController {
 
 	private final MemberService memberService;
 
-	@PostMapping
+	@PostMapping("/sign-up")
 	public ResponseEntity<MemberCreateResponse> createMember(@Valid @RequestBody MemberCreateRequest request) {
 		return ResponseEntity.ok(memberService.createMember(request));
 	}

--- a/src/main/java/com/prgrms/himin/member/application/MemberService.java
+++ b/src/main/java/com/prgrms/himin/member/application/MemberService.java
@@ -26,7 +26,9 @@ public class MemberService {
 	public MemberCreateResponse createMember(MemberCreateRequest request) {
 		Member member = request.toEntity();
 		Address address = new Address(
-			member, request.getAddressAlias(), request.getAddress()
+			member,
+			request.getAddressAlias(),
+			request.getAddress()
 		);
 		member.updateGrade(Grade.NEW);
 		memberRepository.save(member);

--- a/src/main/java/com/prgrms/himin/member/application/MemberService.java
+++ b/src/main/java/com/prgrms/himin/member/application/MemberService.java
@@ -5,7 +5,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.prgrms.himin.member.domain.Address;
 import com.prgrms.himin.member.domain.AddressRepository;
-import com.prgrms.himin.member.domain.Grade;
 import com.prgrms.himin.member.domain.Member;
 import com.prgrms.himin.member.domain.MemberRepository;
 import com.prgrms.himin.member.dto.request.MemberCreateRequest;
@@ -30,9 +29,8 @@ public class MemberService {
 			request.getAddressAlias(),
 			request.getAddress()
 		);
-		member.updateGrade(Grade.NEW);
-		memberRepository.save(member);
-		addressRepository.save(address);
-		return MemberCreateResponse.of(member, address);
+		Member savedMember = memberRepository.save(member);
+		Address savedAddress = addressRepository.save(address);
+		return MemberCreateResponse.of(savedMember, savedAddress);
 	}
 }

--- a/src/main/java/com/prgrms/himin/member/application/MemberService.java
+++ b/src/main/java/com/prgrms/himin/member/application/MemberService.java
@@ -3,7 +3,13 @@ package com.prgrms.himin.member.application;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.prgrms.himin.member.domain.Address;
+import com.prgrms.himin.member.domain.AddressRepository;
+import com.prgrms.himin.member.domain.Grade;
+import com.prgrms.himin.member.domain.Member;
 import com.prgrms.himin.member.domain.MemberRepository;
+import com.prgrms.himin.member.dto.request.MemberCreateRequest;
+import com.prgrms.himin.member.dto.response.MemberCreateResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,4 +19,18 @@ import lombok.RequiredArgsConstructor;
 public class MemberService {
 
 	private final MemberRepository memberRepository;
+
+	private final AddressRepository addressRepository;
+
+	@Transactional
+	public MemberCreateResponse createMember(MemberCreateRequest request) {
+		Member member = request.toEntity();
+		Address address = new Address(
+			member, request.getAddressAlias(), request.getAddress()
+		);
+		member.updateGrade(Grade.NEW);
+		memberRepository.save(member);
+		addressRepository.save(address);
+		return MemberCreateResponse.of(member, address);
+	}
 }

--- a/src/main/java/com/prgrms/himin/member/domain/Address.java
+++ b/src/main/java/com/prgrms/himin/member/domain/Address.java
@@ -32,7 +32,7 @@ public class Address {
 	@Column(name = "addressAlias", nullable = false)
 	private String addressAlias;
 
-	@Column(name = "addressAlias", nullable = false)
+	@Column(name = "address", nullable = false)
 	private String address;
 
 	public Address(

--- a/src/main/java/com/prgrms/himin/member/domain/Address.java
+++ b/src/main/java/com/prgrms/himin/member/domain/Address.java
@@ -29,8 +29,10 @@ public class Address {
 	@JoinColumn(name = "member", nullable = false)
 	private Member member;
 
+	@Column(name = "addressAlias", nullable = false)
 	private String addressAlias;
 
+	@Column(name = "addressAlias", nullable = false)
 	private String address;
 
 	public Address(

--- a/src/main/java/com/prgrms/himin/member/domain/Address.java
+++ b/src/main/java/com/prgrms/himin/member/domain/Address.java
@@ -26,10 +26,10 @@ public class Address {
 	private Long addressId;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member", nullable = false)
+	@JoinColumn(name = "member_id", nullable = false)
 	private Member member;
 
-	@Column(name = "addressAlias", nullable = false)
+	@Column(name = "address_alias", nullable = false)
 	private String addressAlias;
 
 	@Column(name = "address", nullable = false)

--- a/src/main/java/com/prgrms/himin/member/domain/Address.java
+++ b/src/main/java/com/prgrms/himin/member/domain/Address.java
@@ -1,5 +1,45 @@
 package com.prgrms.himin.member.domain;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+@Table(name = "addresses")
 public class Address {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long addressId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member", nullable = false)
+	private Member member;
+
+	private String addressAlias;
+
+	private String address;
+
+	public Address(
+		Member member,
+		String addressAlias,
+		String address
+	) {
+		this.member = member;
+		this.addressAlias = addressAlias;
+		this.address = address;
+	}
 }

--- a/src/main/java/com/prgrms/himin/member/domain/Address.java
+++ b/src/main/java/com/prgrms/himin/member/domain/Address.java
@@ -20,6 +20,10 @@ import lombok.NoArgsConstructor;
 @Table(name = "addresses")
 public class Address {
 
+	private static final int MAX_ADDRESS_LENGTH = 50;
+
+	private static final int MAX_ALIAS_ADDRESS_LENGTH = 10;
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "id")
@@ -29,10 +33,10 @@ public class Address {
 	@JoinColumn(name = "member_id", nullable = false)
 	private Member member;
 
-	@Column(name = "address_alias", nullable = false)
+	@Column(name = "address_alias", nullable = false, length = MAX_ALIAS_ADDRESS_LENGTH)
 	private String addressAlias;
 
-	@Column(name = "address", nullable = false)
+	@Column(name = "address", nullable = false, length = MAX_ADDRESS_LENGTH)
 	private String address;
 
 	public Address(

--- a/src/main/java/com/prgrms/himin/member/domain/AddressRepository.java
+++ b/src/main/java/com/prgrms/himin/member/domain/AddressRepository.java
@@ -1,0 +1,6 @@
+package com.prgrms.himin.member.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AddressRepository extends JpaRepository<Address, Long> {
+}

--- a/src/main/java/com/prgrms/himin/member/domain/Grade.java
+++ b/src/main/java/com/prgrms/himin/member/domain/Grade.java
@@ -1,4 +1,7 @@
 package com.prgrms.himin.member.domain;
 
 public enum Grade {
+	NEW,
+	COMMON,
+	VIP
 }

--- a/src/main/java/com/prgrms/himin/member/domain/Member.java
+++ b/src/main/java/com/prgrms/himin/member/domain/Member.java
@@ -43,7 +43,7 @@ public class Member {
 	@Column(name = "name", nullable = false, length = NAME_MAX_LENGTH)
 	private String name;
 
-	@Column(name = "phone", nullable = false, length = 15)
+	@Column(name = "phone", nullable = false, length = PHONE_MAX_LENGTH)
 	private String phone;
 
 	@Column(name = "birthday", nullable = false)
@@ -59,8 +59,7 @@ public class Member {
 		String password,
 		String name,
 		String phone,
-		LocalDate birthday,
-		Grade grade
+		LocalDate birthday
 	) {
 		validateLoginId(loginId);
 		validatePassword(password);
@@ -71,7 +70,7 @@ public class Member {
 		this.name = name;
 		this.phone = phone;
 		this.birthday = birthday;
-		this.grade = grade;
+		this.grade = Grade.NEW;
 	}
 
 	public void updateGrade(Grade grade) {

--- a/src/main/java/com/prgrms/himin/member/domain/Member.java
+++ b/src/main/java/com/prgrms/himin/member/domain/Member.java
@@ -4,39 +4,105 @@ import java.time.LocalDate;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
 import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "members")
 public class Member {
+
+	private static final int ID_MAX_LENGTH = 20;
+
+	private static final int PASSWORD_MAX_LENGTH = 20;
+
+	private static final int NAME_MAX_LENGTH = 10;
+
+	private static final int PHONE_MAX_LENGTH = 15;
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "id")
 	private Long id;
 
-	@Column(name = "login_id", nullable = false, length = 20)
+	@Column(name = "login_id", nullable = false, length = ID_MAX_LENGTH)
 	private String loginId;
 
-	@Column(name = "password", nullable = false, length = 60)
+	@Column(name = "password", nullable = false, length = PASSWORD_MAX_LENGTH)
 	private String password;
 
-	@Column(name = "id", nullable = false, length = 20)
+	@Column(name = "name", nullable = false, length = NAME_MAX_LENGTH)
 	private String name;
 
-	@Column(name = "id", nullable = false, length = 15)
+	@Column(name = "phone", nullable = false, length = 15)
 	private String phone;
 
-	@Column(name = "id", nullable = false)
+	@Column(name = "birthday", nullable = false)
 	private LocalDate birthday;
 
-	@Column(name = "id", nullable = false)
+	@Enumerated
+	@Column(name = "grade", nullable = false)
 	private Grade grade;
+
+	@Builder
+	public Member(
+		String loginId,
+		String password,
+		String name,
+		String phone,
+		LocalDate birthday,
+		Grade grade
+	) {
+		this.loginId = loginId;
+		this.password = password;
+		this.name = name;
+		this.phone = phone;
+		this.birthday = birthday;
+		this.grade = grade;
+		validateAll();
+	}
+
+	public void updateGrade(Grade grade) {
+		this.grade = grade;
+	}
+
+	private void validateAll() {
+		validateLoginId(loginId);
+		validatePassword(password);
+		validatename(name);
+		validatePhone(phone);
+	}
+
+	private void validateLoginId(String loginId) {
+		if (loginId == null || loginId.length() > ID_MAX_LENGTH) {
+			throw new RuntimeException("잘못된 로그인ID입니다.");
+		}
+	}
+
+	private void validatePassword(String password) {
+		if (password == null || password.length() > PASSWORD_MAX_LENGTH) {
+			throw new RuntimeException("잘못된 비밀번호입니다.");
+		}
+	}
+
+	private void validatename(String name) {
+		if (name == null || name.length() > NAME_MAX_LENGTH) {
+			throw new RuntimeException("잘못된 이름입니다.");
+		}
+	}
+
+	private void validatePhone(String phone) {
+		if (phone == null || phone.length() > PHONE_MAX_LENGTH) {
+			throw new RuntimeException("잘못된 핸드폰번호입니다.");
+		}
+	}
 }

--- a/src/main/java/com/prgrms/himin/member/domain/Member.java
+++ b/src/main/java/com/prgrms/himin/member/domain/Member.java
@@ -62,24 +62,20 @@ public class Member {
 		LocalDate birthday,
 		Grade grade
 	) {
+		validateLoginId(loginId);
+		validatePassword(password);
+		validateName(name);
+		validatePhone(phone);
 		this.loginId = loginId;
 		this.password = password;
 		this.name = name;
 		this.phone = phone;
 		this.birthday = birthday;
 		this.grade = grade;
-		validateAll();
 	}
 
 	public void updateGrade(Grade grade) {
 		this.grade = grade;
-	}
-
-	private void validateAll() {
-		validateLoginId(loginId);
-		validatePassword(password);
-		validatename(name);
-		validatePhone(phone);
 	}
 
 	private void validateLoginId(String loginId) {
@@ -94,7 +90,7 @@ public class Member {
 		}
 	}
 
-	private void validatename(String name) {
+	private void validateName(String name) {
 		if (name == null || name.length() > NAME_MAX_LENGTH) {
 			throw new RuntimeException("잘못된 이름입니다.");
 		}

--- a/src/main/java/com/prgrms/himin/member/dto/request/MemberCreateRequest.java
+++ b/src/main/java/com/prgrms/himin/member/dto/request/MemberCreateRequest.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -17,15 +18,19 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public final class MemberCreateRequest {
 
+	@Size(max = 20, message = "loginId은 최대 20글자 입니다.")
 	@NotBlank(message = "loginId가 비어있으면 안됩니다.")
 	private final String loginId;
 
+	@Size(max = 20, message = "비밀번호는 최대 20글자 입니다.")
 	@NotBlank(message = "비밀번호가 비어있으면 안됩니다.")
 	private final String password;
 
+	@Size(max = 10, message = "이름은 최대 20글자 입니다.")
 	@NotBlank(message = "이름이 비어있으면 안됩니다.")
 	private final String name;
 
+	@Size(max = 15, message = "핸드폰번호는 최대 20글자 입니다.")
 	@NotBlank(message = "핸드폰번호가 비어있으면 안됩니다.")
 	private final String phone;
 

--- a/src/main/java/com/prgrms/himin/member/dto/request/MemberCreateRequest.java
+++ b/src/main/java/com/prgrms/himin/member/dto/request/MemberCreateRequest.java
@@ -1,0 +1,51 @@
+package com.prgrms.himin.member.dto.request;
+
+import java.time.LocalDate;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import com.prgrms.himin.member.domain.Member;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public final class MemberCreateRequest {
+
+	@NotBlank(message = "loginId가 비어있으면 안됩니다.")
+	private final String loginId;
+
+	@NotBlank(message = "비밀번호가 비어있으면 안됩니다.")
+	private final String password;
+
+	@NotBlank(message = "이름이 비어있으면 안됩니다.")
+	private final String name;
+
+	@NotBlank(message = "핸드폰번호가 비어있으면 안됩니다.")
+	private final String phone;
+
+	@NotNull(message = "생일값이 null이면 안됩니다.")
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+	private final LocalDate birthday;
+
+	@NotBlank(message = "주소 가명이 비어있으면 안됩니다.")
+	private final String addressAlias;
+
+	@NotBlank(message = "주소가 비어있으면 안됩니다.")
+	private final String address;
+
+	public Member toEntity() {
+		return Member.builder()
+			.loginId(loginId)
+			.password(password)
+			.name(name)
+			.phone(phone)
+			.birthday(birthday)
+			.build();
+	}
+}

--- a/src/main/java/com/prgrms/himin/member/dto/response/MemberCreateResponse.java
+++ b/src/main/java/com/prgrms/himin/member/dto/response/MemberCreateResponse.java
@@ -1,0 +1,59 @@
+package com.prgrms.himin.member.dto.response;
+
+import java.time.LocalDate;
+
+import com.prgrms.himin.member.domain.Address;
+import com.prgrms.himin.member.domain.Grade;
+import com.prgrms.himin.member.domain.Member;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberCreateResponse {
+
+	private final Long id;
+
+	private final String loginId;
+
+	private final String name;
+
+	private final String phone;
+
+	private final LocalDate birthday;
+
+	private final Grade grade;
+
+	private final Address address;
+
+	@Builder
+	public MemberCreateResponse(
+		Long id,
+		String loginId,
+		String name,
+		String phone,
+		LocalDate birthday,
+		Grade grade,
+		Address address
+	) {
+		this.id = id;
+		this.loginId = loginId;
+		this.name = name;
+		this.phone = phone;
+		this.birthday = birthday;
+		this.grade = grade;
+		this.address = address;
+	}
+
+	public static MemberCreateResponse of(Member member, Address address) {
+		return MemberCreateResponse.builder()
+			.id(member.getId())
+			.loginId(member.getLoginId())
+			.name(member.getName())
+			.phone(member.getPhone())
+			.birthday(member.getBirthday())
+			.grade(member.getGrade())
+			.address(address)
+			.build();
+	}
+}

--- a/src/main/java/com/prgrms/himin/member/dto/response/MemberCreateResponse.java
+++ b/src/main/java/com/prgrms/himin/member/dto/response/MemberCreateResponse.java
@@ -10,7 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class MemberCreateResponse {
+public final class MemberCreateResponse {
 
 	private final Long id;
 


### PR DESCRIPTION
## PR 확인 항목 
PR 보내기전에 아래 항목들을 만족 하였는지 체크 해주세요 

- [x] 곤모슬 팀에서 정한 커밋 메시지 규칙과 일치하는가?
- [x] 곤모슬 팀에서 정한 코딩 컨벤션과 일치하는가?

## PR 종류
어떤 종류의 PR인지 아래 항목중에 체크 해주세요
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 변경 (formatting, local variables)
- [ ] 리팩토링 (기능 변경 X)
- [ ] 빌드 관련 수정
- [ ] 문서 내용 수정
- [ ] 그 외, 어떤 종류인지 기입 바람:


## 어떤 기능이 추가 되었나요?
<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->
회원 가입기능을 위해, 다음 클래스에서 해당사항을 구현했습니다.
### Member

- 팀 규칙으로 엔티티 생성자에서 비즈니스 요구사항에 대한 validation을 진행해 주었습니다.
- 추후 멤버등급이 업그레이드 될 것을 생각해, `updateGrade`메소드를 만들어 주었습니다.

### MemberService

- Member가입시 기입됐던 address와 addressAlias, member를 Address 객체로 만든 후,
    
    Address - Member 연관관계를 위해 생성자에 모두 넣어주었습니다.
    
- 멤버를 생성할 시에는 `updateGrade` 메소드를 호출하여 NEW 등급을 할당해 주었습니다.
- member가 address를 참조하지 않으므로, 각각의 repository에 save합니다.

### Address

- member와 다(address)대일(member) 단방향 연관관계에 놓여 있습니다.
- 단방향으로 설정해 둔 이유는,
1. member가 address를 참조할 이유가 따로 없음.
2. 두 도메인의 생성시기가 다른 경우가 잦음. (비즈니스 요구사항 상, member의 Address를 상시로 추가 / 삭제가 가능하므로.)



Issue Number: HIMIN-72


## 기존에 있던 기능에 영향을 주나요?

- [ ] 네
- [x] 아니요


<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


## 기타

