### PR TITLE
[HIMIN-77] feat : 멤버 단건 조회 구현

### DIFF
--- a/src/main/java/com/prgrms/himin/member/api/MemberController.java
+++ b/src/main/java/com/prgrms/himin/member/api/MemberController.java
@@ -3,6 +3,8 @@ package com.prgrms.himin.member.api;
 import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,6 +14,7 @@ import com.prgrms.himin.member.application.MemberService;
 import com.prgrms.himin.member.dto.request.MemberCreateRequest;
 import com.prgrms.himin.member.dto.request.MemberLoginRequest;
 import com.prgrms.himin.member.dto.response.MemberCreateResponse;
+import com.prgrms.himin.member.dto.response.MemberResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -32,5 +35,11 @@ public class MemberController {
 	public ResponseEntity<Void> login(@Valid @RequestBody MemberLoginRequest request) {
 		memberService.login(request);
 		return ResponseEntity.ok().build();
+	}
+
+	@GetMapping("/members/{memberId}")
+	public ResponseEntity<MemberResponse> getMember(@PathVariable Long memberId) {
+		MemberResponse response = memberService.getMember(memberId);
+		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/prgrms/himin/member/api/MemberController.java
+++ b/src/main/java/com/prgrms/himin/member/api/MemberController.java
@@ -24,7 +24,8 @@ public class MemberController {
 
 	@PostMapping("/sign-up")
 	public ResponseEntity<MemberCreateResponse> createMember(@Valid @RequestBody MemberCreateRequest request) {
-		return ResponseEntity.ok(memberService.createMember(request));
+		MemberCreateResponse response = memberService.createMember(request);
+		return ResponseEntity.ok(response);
 	}
 
 	@PostMapping("/sign-in")

--- a/src/main/java/com/prgrms/himin/member/application/MemberService.java
+++ b/src/main/java/com/prgrms/himin/member/application/MemberService.java
@@ -1,14 +1,21 @@
 package com.prgrms.himin.member.application;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.prgrms.himin.global.error.exception.EntityNotFoundException;
+import com.prgrms.himin.global.error.exception.ErrorCode;
 import com.prgrms.himin.member.domain.Address;
 import com.prgrms.himin.member.domain.Member;
 import com.prgrms.himin.member.domain.MemberRepository;
 import com.prgrms.himin.member.dto.request.MemberCreateRequest;
 import com.prgrms.himin.member.dto.request.MemberLoginRequest;
+import com.prgrms.himin.member.dto.response.AddressResponse;
 import com.prgrms.himin.member.dto.response.MemberCreateResponse;
+import com.prgrms.himin.member.dto.response.MemberResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -38,5 +45,15 @@ public class MemberService {
 		)) {
 			throw new RuntimeException("로그인할 정보가 일치하지 않습니다!");
 		}
+	}
+
+	public MemberResponse getMember(Long memberId) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+		List<AddressResponse> addresses = member.getAddresses()
+			.stream()
+			.map(AddressResponse::from)
+			.collect(Collectors.toList());
+		return MemberResponse.from(member, addresses);
 	}
 }

--- a/src/main/java/com/prgrms/himin/member/application/MemberService.java
+++ b/src/main/java/com/prgrms/himin/member/application/MemberService.java
@@ -54,6 +54,6 @@ public class MemberService {
 			.stream()
 			.map(AddressResponse::from)
 			.collect(Collectors.toList());
-		return MemberResponse.from(member, addresses);
+		return MemberResponse.of(member, addresses);
 	}
 }

--- a/src/main/java/com/prgrms/himin/member/application/MemberService.java
+++ b/src/main/java/com/prgrms/himin/member/application/MemberService.java
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.prgrms.himin.member.domain.Address;
-import com.prgrms.himin.member.domain.AddressRepository;
 import com.prgrms.himin.member.domain.Member;
 import com.prgrms.himin.member.domain.MemberRepository;
 import com.prgrms.himin.member.dto.request.MemberCreateRequest;
@@ -20,19 +19,16 @@ public class MemberService {
 
 	private final MemberRepository memberRepository;
 
-	private final AddressRepository addressRepository;
-
 	@Transactional
 	public MemberCreateResponse createMember(MemberCreateRequest request) {
 		Member member = request.toEntity();
 		Address address = new Address(
-			member,
 			request.getAddressAlias(),
 			request.getAddress()
 		);
+		address.attachTo(member);
 		Member savedMember = memberRepository.save(member);
-		Address savedAddress = addressRepository.save(address);
-		return MemberCreateResponse.of(savedMember, savedAddress);
+		return MemberCreateResponse.from(savedMember);
 	}
 
 	public void login(MemberLoginRequest request) {

--- a/src/main/java/com/prgrms/himin/member/domain/Address.java
+++ b/src/main/java/com/prgrms/himin/member/domain/Address.java
@@ -10,6 +10,8 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,6 +31,7 @@ public class Address {
 	@Column(name = "id")
 	private Long addressId;
 
+	@JsonIgnore
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id", nullable = false)
 	private Member member;
@@ -40,12 +43,18 @@ public class Address {
 	private String address;
 
 	public Address(
-		Member member,
 		String addressAlias,
 		String address
 	) {
-		this.member = member;
 		this.addressAlias = addressAlias;
 		this.address = address;
+	}
+
+	public void attachTo(Member member) {
+		if (this.member != null) {
+			this.member.removeAddress(this);
+		}
+		this.member = member;
+		member.addAddress(this);
 	}
 }

--- a/src/main/java/com/prgrms/himin/member/domain/Address.java
+++ b/src/main/java/com/prgrms/himin/member/domain/Address.java
@@ -10,8 +10,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -31,7 +29,6 @@ public class Address {
 	@Column(name = "id")
 	private Long addressId;
 
-	@JsonIgnore
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id", nullable = false)
 	private Member member;

--- a/src/main/java/com/prgrms/himin/member/domain/Member.java
+++ b/src/main/java/com/prgrms/himin/member/domain/Member.java
@@ -1,13 +1,17 @@
 package com.prgrms.himin.member.domain;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
 import lombok.AccessLevel;
@@ -53,6 +57,9 @@ public class Member {
 	@Column(name = "grade", nullable = false)
 	private Grade grade;
 
+	@OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+	private List<Address> addresses = new ArrayList<>();
+
 	@Builder
 	public Member(
 		String loginId,
@@ -75,6 +82,14 @@ public class Member {
 
 	public void updateGrade(Grade grade) {
 		this.grade = grade;
+	}
+
+	public void addAddress(Address address) {
+		addresses.add(address);
+	}
+
+	public void removeAddress(Address address) {
+		addresses.remove(address);
 	}
 
 	private void validateLoginId(String loginId) {

--- a/src/main/java/com/prgrms/himin/member/domain/Member.java
+++ b/src/main/java/com/prgrms/himin/member/domain/Member.java
@@ -7,6 +7,7 @@ import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -53,7 +54,7 @@ public class Member {
 	@Column(name = "birthday", nullable = false)
 	private LocalDate birthday;
 
-	@Enumerated
+	@Enumerated(EnumType.STRING)
 	@Column(name = "grade", nullable = false)
 	private Grade grade;
 

--- a/src/main/java/com/prgrms/himin/member/dto/response/AddressResponse.java
+++ b/src/main/java/com/prgrms/himin/member/dto/response/AddressResponse.java
@@ -1,0 +1,35 @@
+package com.prgrms.himin.member.dto.response;
+
+import com.prgrms.himin.member.domain.Address;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public final class AddressResponse {
+
+	private final Long addressId;
+
+	private final String address;
+
+	private final String addressAlias;
+
+	@Builder
+	public AddressResponse(
+		Long addressId,
+		String address,
+		String addressAlias
+	) {
+		this.addressId = addressId;
+		this.address = address;
+		this.addressAlias = addressAlias;
+	}
+
+	public static AddressResponse from(Address address) {
+		return AddressResponse.builder()
+			.addressId(address.getAddressId())
+			.address(address.getAddress())
+			.addressAlias(address.getAddressAlias())
+			.build();
+	}
+}

--- a/src/main/java/com/prgrms/himin/member/dto/response/AddressResponse.java
+++ b/src/main/java/com/prgrms/himin/member/dto/response/AddressResponse.java
@@ -2,7 +2,6 @@ package com.prgrms.himin.member.dto.response;
 
 import com.prgrms.himin.member.domain.Address;
 
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -14,8 +13,7 @@ public final class AddressResponse {
 
 	private final String addressAlias;
 
-	@Builder
-	public AddressResponse(
+	private AddressResponse(
 		Long addressId,
 		String address,
 		String addressAlias
@@ -26,10 +24,10 @@ public final class AddressResponse {
 	}
 
 	public static AddressResponse from(Address address) {
-		return AddressResponse.builder()
-			.addressId(address.getAddressId())
-			.address(address.getAddress())
-			.addressAlias(address.getAddressAlias())
-			.build();
+		return new AddressResponse(
+			address.getAddressId(),
+			address.getAddress(),
+			address.getAddressAlias()
+		);
 	}
 }

--- a/src/main/java/com/prgrms/himin/member/dto/response/MemberCreateResponse.java
+++ b/src/main/java/com/prgrms/himin/member/dto/response/MemberCreateResponse.java
@@ -2,8 +2,8 @@ package com.prgrms.himin.member.dto.response;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
-import com.prgrms.himin.member.domain.Address;
 import com.prgrms.himin.member.domain.Grade;
 import com.prgrms.himin.member.domain.Member;
 
@@ -25,17 +25,17 @@ public final class MemberCreateResponse {
 
 	private final Grade grade;
 
-	private final List<Address> addresses;
+	private final List<AddressResponse> addresses;
 
 	@Builder
-	public MemberCreateResponse(
+	private MemberCreateResponse(
 		Long id,
 		String loginId,
 		String name,
 		String phone,
 		LocalDate birthday,
 		Grade grade,
-		List<Address> addresses
+		List<AddressResponse> addresses
 	) {
 		this.id = id;
 		this.loginId = loginId;
@@ -54,7 +54,10 @@ public final class MemberCreateResponse {
 			.phone(member.getPhone())
 			.birthday(member.getBirthday())
 			.grade(member.getGrade())
-			.addresses(member.getAddresses())
+			.addresses(member.getAddresses()
+				.stream()
+				.map(AddressResponse::from)
+				.collect(Collectors.toList()))
 			.build();
 	}
 }

--- a/src/main/java/com/prgrms/himin/member/dto/response/MemberCreateResponse.java
+++ b/src/main/java/com/prgrms/himin/member/dto/response/MemberCreateResponse.java
@@ -1,6 +1,7 @@
 package com.prgrms.himin.member.dto.response;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import com.prgrms.himin.member.domain.Address;
 import com.prgrms.himin.member.domain.Grade;
@@ -24,7 +25,7 @@ public final class MemberCreateResponse {
 
 	private final Grade grade;
 
-	private final Address address;
+	private final List<Address> addresses;
 
 	@Builder
 	public MemberCreateResponse(
@@ -34,7 +35,7 @@ public final class MemberCreateResponse {
 		String phone,
 		LocalDate birthday,
 		Grade grade,
-		Address address
+		List<Address> addresses
 	) {
 		this.id = id;
 		this.loginId = loginId;
@@ -42,10 +43,10 @@ public final class MemberCreateResponse {
 		this.phone = phone;
 		this.birthday = birthday;
 		this.grade = grade;
-		this.address = address;
+		this.addresses = addresses;
 	}
 
-	public static MemberCreateResponse of(Member member, Address address) {
+	public static MemberCreateResponse from(Member member) {
 		return MemberCreateResponse.builder()
 			.id(member.getId())
 			.loginId(member.getLoginId())
@@ -53,7 +54,7 @@ public final class MemberCreateResponse {
 			.phone(member.getPhone())
 			.birthday(member.getBirthday())
 			.grade(member.getGrade())
-			.address(address)
+			.addresses(member.getAddresses())
 			.build();
 	}
 }

--- a/src/main/java/com/prgrms/himin/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/prgrms/himin/member/dto/response/MemberResponse.java
@@ -27,7 +27,7 @@ public final class MemberResponse {
 	private final List<AddressResponse> addresses;
 
 	@Builder
-	public MemberResponse(
+	private MemberResponse(
 		Long id,
 		String loginId,
 		String name,
@@ -45,7 +45,7 @@ public final class MemberResponse {
 		this.addresses = addresses;
 	}
 
-	public static MemberResponse from(Member member, List<AddressResponse> addresses) {
+	public static MemberResponse of(Member member, List<AddressResponse> addresses) {
 		return MemberResponse.builder()
 			.id(member.getId())
 			.loginId(member.getLoginId())

--- a/src/main/java/com/prgrms/himin/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/prgrms/himin/member/dto/response/MemberResponse.java
@@ -1,0 +1,59 @@
+package com.prgrms.himin.member.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.prgrms.himin.member.domain.Grade;
+import com.prgrms.himin.member.domain.Member;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public final class MemberResponse {
+
+	private final Long id;
+
+	private final String loginId;
+
+	private final String name;
+
+	private final String phone;
+
+	private final LocalDate birthday;
+
+	private final Grade grade;
+
+	private final List<AddressResponse> addresses;
+
+	@Builder
+	public MemberResponse(
+		Long id,
+		String loginId,
+		String name,
+		String phone,
+		LocalDate birthday,
+		Grade grade,
+		List<AddressResponse> addresses
+	) {
+		this.id = id;
+		this.loginId = loginId;
+		this.name = name;
+		this.phone = phone;
+		this.birthday = birthday;
+		this.grade = grade;
+		this.addresses = addresses;
+	}
+
+	public static MemberResponse from(Member member, List<AddressResponse> addresses) {
+		return MemberResponse.builder()
+			.id(member.getId())
+			.loginId(member.getLoginId())
+			.name(member.getName())
+			.phone(member.getPhone())
+			.birthday(member.getBirthday())
+			.grade(member.getGrade())
+			.addresses(addresses)
+			.build();
+	}
+}


### PR DESCRIPTION
## PR 확인 항목 
PR 보내기전에 아래 항목들을 만족 하였는지 체크 해주세요 

- [x] 곤모슬 팀에서 정한 커밋 메시지 규칙과 일치하는가?
- [x] 곤모슬 팀에서 정한 코딩 컨벤션과 일치하는가?

## PR 종류
어떤 종류의 PR인지 아래 항목중에 체크 해주세요
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 변경 (formatting, local variables)
- [ ] 리팩토링 (기능 변경 X)
- [ ] 빌드 관련 수정
- [ ] 문서 내용 수정
- [ ] 그 외, 어떤 종류인지 기입 바람:


## 어떤 기능이 추가 되었나요?
<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->
### Member ↔ Address 양방향 매핑

- 기존에는 Address → Member 단방향 매핑이였지만, Member의 Address list를 효과적으로 반환하기 위해 양방향 매핑으로 변경하였습니다.
- 그에 따라 연관관계 편의 메소드도 구현하였습니다.

### MemberService

- 회원 단건조회 기능인 `getMember`메소드를 구현했습니다.
- 해당 메소드 내에서 회원을 먼저 조회하고, 회원의 List<Address>리스트를 List<AddressResponse>로 바꿔줍니다. (엔티티가 아닌, Dto반환을 위함. JSON 직렬화 시에도 문제가 생겨 Dto로 바꾸어 주었습니다. 이유는 추후 찾아볼 예정입니다.)

Issue Number: N/A
HIMIN-77

## 기존에 있던 기능에 영향을 주나요?

- [ ] 네
- [x] 아니요


<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


## 기타

