### PR TITLE
[HIMIN-73] feat: 가게 조건 검색 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,36 +1,44 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '2.7.15'
-	id 'io.spring.dependency-management' version '1.1.3'
+    id 'java'
+    id 'org.springframework.boot' version '2.7.15'
+    id 'io.spring.dependency-management' version '1.1.3'
 }
 
 group = 'com.prgrms'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '11'
+    sourceCompatibility = '11'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    // QueryDSL 추가
+    implementation 'com.querydsl:querydsl-jpa'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
-tasks.named('test') {
-	useJUnitPlatform()
+// Querydsl 추가, 자동 생성된 Q클래스 gradle clean으로 제거
+clean {
+    delete file('src/main/generated')
 }
+

--- a/src/main/java/com/prgrms/himin/global/config/QueryDslConfig.java
+++ b/src/main/java/com/prgrms/himin/global/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.prgrms.himin.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/prgrms/himin/shop/api/ShopController.java
+++ b/src/main/java/com/prgrms/himin/shop/api/ShopController.java
@@ -1,6 +1,7 @@
 package com.prgrms.himin.shop.api;
 
 import com.prgrms.himin.shop.application.ShopService;
+import com.prgrms.himin.shop.domain.Category;
 import com.prgrms.himin.shop.dto.request.ShopCreateRequest;
 import com.prgrms.himin.shop.dto.request.ShopUpdateRequest;
 import com.prgrms.himin.shop.dto.response.ShopResponse;
@@ -9,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -27,6 +29,22 @@ public class ShopController {
     public ResponseEntity<ShopResponse> getShop(@PathVariable Long shopId) {
         ShopResponse response = shopService.getShop(shopId);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ShopResponse>> getShops(
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) Category category,
+            @RequestParam(required = false) String address,
+            @RequestParam(required = false) Integer deliveryTip
+    ) {
+        List<ShopResponse> responses = shopService.getShops(
+                name,
+                category,
+                address,
+                deliveryTip
+        );
+        return ResponseEntity.ok(responses);
     }
 
     @PutMapping("/{shopId}")

--- a/src/main/java/com/prgrms/himin/shop/application/ShopService.java
+++ b/src/main/java/com/prgrms/himin/shop/application/ShopService.java
@@ -1,5 +1,6 @@
 package com.prgrms.himin.shop.application;
 
+import com.prgrms.himin.shop.domain.Category;
 import com.prgrms.himin.shop.domain.Shop;
 import com.prgrms.himin.shop.domain.ShopRepository;
 import com.prgrms.himin.shop.dto.request.ShopCreateRequest;
@@ -8,6 +9,9 @@ import com.prgrms.himin.shop.dto.response.ShopResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +31,23 @@ public class ShopService {
         Shop shop = shopRepository.findById(shopId)
                 .orElseThrow(() -> new RuntimeException("가게를 찾을 수 없습니다."));
         return ShopResponse.from(shop);
+    }
+
+    public List<ShopResponse> getShops(
+            String name,
+            Category category,
+            String address,
+            Integer deliveryTip
+    ) {
+        List<Shop> shops = shopRepository.searchShops(
+                name,
+                category,
+                address,
+                deliveryTip
+        );
+        return shops.stream()
+                .map(ShopResponse::from)
+                .collect(Collectors.toList());
     }
 
     @Transactional

--- a/src/main/java/com/prgrms/himin/shop/dao/ShopRepositoryImpl.java
+++ b/src/main/java/com/prgrms/himin/shop/dao/ShopRepositoryImpl.java
@@ -1,0 +1,52 @@
+package com.prgrms.himin.shop.dao;
+
+import com.prgrms.himin.shop.domain.Category;
+import com.prgrms.himin.shop.domain.Shop;
+import com.prgrms.himin.shop.domain.ShopRepositoryCustom;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.prgrms.himin.shop.domain.QShop.shop;
+
+@Repository
+public class ShopRepositoryImpl implements ShopRepositoryCustom {
+
+    @Autowired
+    private JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Shop> searchShops(String name,
+                                  Category category,
+                                  String address,
+                                  Integer deliveryTip
+    ) {
+        return jpaQueryFactory.selectFrom(shop)
+                .where(
+                        containsName(name),
+                        eqCategory(category),
+                        containsAddress(address),
+                        loeDeliveryTip(deliveryTip)
+                )
+                .fetch();
+    }
+
+    private BooleanExpression containsName(String name) {
+        return name != null ? shop.name.contains(name) : null;
+    }
+
+    private BooleanExpression eqCategory(Category category) {
+        return category != null ? shop.category.eq(category) : null;
+    }
+
+    private BooleanExpression containsAddress(String address) {
+        return address != null ? shop.address.contains(address) : null;
+    }
+
+    private BooleanExpression loeDeliveryTip(Integer deliveryTip) {
+        return deliveryTip != null ? shop.deliveryTip.loe(deliveryTip) : null;
+    }
+}

--- a/src/main/java/com/prgrms/himin/shop/domain/ShopRepository.java
+++ b/src/main/java/com/prgrms/himin/shop/domain/ShopRepository.java
@@ -2,5 +2,5 @@ package com.prgrms.himin.shop.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ShopRepository extends JpaRepository<Shop, Long> {
+public interface ShopRepository extends JpaRepository<Shop, Long>, ShopRepositoryCustom {
 }

--- a/src/main/java/com/prgrms/himin/shop/domain/ShopRepositoryCustom.java
+++ b/src/main/java/com/prgrms/himin/shop/domain/ShopRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.prgrms.himin.shop.domain;
+
+import java.util.List;
+
+public interface ShopRepositoryCustom {
+
+    List<Shop> searchShops(
+            String name,
+            Category category,
+            String address,
+            Integer deliveryTip
+    );
+}


### PR DESCRIPTION
## PR 확인 항목 
PR 보내기전에 아래 항목들을 만족 하였는지 체크 해주세요 

- [x] 곤모슬 팀에서 정한 커밋 메시지 규칙과 일치하는가?
- [x] 곤모슬 팀에서 정한 코딩 컨벤션과 일치하는가?

## PR 종류
어떤 종류의 PR인지 아래 항목중에 체크 해주세요
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 변경 (formatting, local variables)
- [ ] 리팩토링 (기능 변경 X)
- [x] 빌드 관련 수정
- [ ] 문서 내용 수정
- [ ] 그 외, 어떤 종류인지 기입 바람:


## 어떤 기능이 추가 되었나요?
<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### QueryDsl 의존성 및 설정 추가
- build.gradle에 QueryDsl 관련 설정들을 추가하였습니다.
- global 하위 config 패키지를 만들어 QueryDsl을 사용하기 위한 설정 파일을 추가하였습니다.

### 가게 조건 검색 기능 구현
- 가능한 검색 조건은 가게 이름, 주소, 카테고리, 배달팁 입니다.
- 쿼리 파라미터로 위의 조건들을 받아옵니다. 원하는 조건에 대해서만 검색합니다.
- 가게 이름으로 검색
    - 입력한 가게 이름을 포함하는 모든 가게를 조회합니다.
- 주소로 검색
    - 입력한 주소를 포함하는 모든 가게를 조회합니다.
- 카테고리로 검색
    - 입력한 카테고리에 해당하는 모든 가게를 조회합니다.
- 배달팁으로 검색
    - 입력한 배달팁 이하의 배달팁을 가진 모든 가게를 조회합니다.

### 검색 URL 예시
`http://localhost:8080/api/shops?deliveryTip=2000&address=7`
- 배달팁이 2000원 이하이고, 주소에 '7'이 들어간 모든 가게를 조회한다.

Issue Number: HIMIN-73


## 기존에 있던 기능에 영향을 주나요?

- [ ] 네
- [x] 아니요


<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


## 기타

