### PR TITLE
[HIMIN-100] feat : address 생성 구현

### DIFF
--- a/src/main/java/com/prgrms/himin/member/api/MemberController.java
+++ b/src/main/java/com/prgrms/himin/member/api/MemberController.java
@@ -12,8 +12,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.prgrms.himin.member.application.MemberService;
+import com.prgrms.himin.member.dto.request.AddressCreateRequest;
 import com.prgrms.himin.member.dto.request.MemberCreateRequest;
 import com.prgrms.himin.member.dto.request.MemberLoginRequest;
+import com.prgrms.himin.member.dto.response.AddressResponse;
 import com.prgrms.himin.member.dto.response.MemberCreateResponse;
 import com.prgrms.himin.member.dto.response.MemberResponse;
 
@@ -48,5 +50,13 @@ public class MemberController {
 	public ResponseEntity<Void> deleteMember(@PathVariable Long memberId) {
 		memberService.deleteMember(memberId);
 		return ResponseEntity.ok().build();
+	}
+
+	@PostMapping("/members/{memberId}/addresses")
+	public ResponseEntity<AddressResponse> createAddress(
+		@PathVariable Long memberId,
+		@Valid @RequestBody AddressCreateRequest request) {
+		AddressResponse response = memberService.createAddress(memberId, request);
+		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/prgrms/himin/member/application/MemberService.java
+++ b/src/main/java/com/prgrms/himin/member/application/MemberService.java
@@ -9,8 +9,10 @@ import org.springframework.transaction.annotation.Transactional;
 import com.prgrms.himin.global.error.exception.EntityNotFoundException;
 import com.prgrms.himin.global.error.exception.ErrorCode;
 import com.prgrms.himin.member.domain.Address;
+import com.prgrms.himin.member.domain.AddressRepository;
 import com.prgrms.himin.member.domain.Member;
 import com.prgrms.himin.member.domain.MemberRepository;
+import com.prgrms.himin.member.dto.request.AddressCreateRequest;
 import com.prgrms.himin.member.dto.request.MemberCreateRequest;
 import com.prgrms.himin.member.dto.request.MemberLoginRequest;
 import com.prgrms.himin.member.dto.response.AddressResponse;
@@ -25,6 +27,8 @@ import lombok.RequiredArgsConstructor;
 public class MemberService {
 
 	private final MemberRepository memberRepository;
+
+	private final AddressRepository addressRepository;
 
 	@Transactional
 	public MemberCreateResponse createMember(MemberCreateRequest request) {
@@ -63,5 +67,15 @@ public class MemberService {
 			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
 
 		memberRepository.delete(member);
+	}
+
+	@Transactional
+	public AddressResponse createAddress(Long memberId, AddressCreateRequest request) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+		Address address = request.toEntity();
+		address.attachTo(member);
+		Address savedAddress = addressRepository.save(address);
+		return AddressResponse.from(savedAddress);
 	}
 }

--- a/src/main/java/com/prgrms/himin/member/domain/Address.java
+++ b/src/main/java/com/prgrms/himin/member/domain/Address.java
@@ -1,5 +1,7 @@
 package com.prgrms.himin.member.domain;
 
+import java.util.Objects;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -55,6 +57,21 @@ public class Address {
 		}
 		this.member = member;
 		member.addAddress(this);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		Address address1 = (Address)o;
+		return Objects.equals(addressId, address1.addressId);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(addressId, member, addressAlias, address);
 	}
 
 	private void validateAddress(String address) {

--- a/src/main/java/com/prgrms/himin/member/domain/Member.java
+++ b/src/main/java/com/prgrms/himin/member/domain/Member.java
@@ -86,6 +86,9 @@ public class Member {
 	}
 
 	public void addAddress(Address address) {
+		if (addresses.contains(address)) {
+			return;
+		}
 		addresses.add(address);
 	}
 

--- a/src/main/java/com/prgrms/himin/member/dto/request/AddressCreateRequest.java
+++ b/src/main/java/com/prgrms/himin/member/dto/request/AddressCreateRequest.java
@@ -1,0 +1,30 @@
+package com.prgrms.himin.member.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
+import com.prgrms.himin.member.domain.Address;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public class AddressCreateRequest {
+
+	@Size(max = 10, message = "주소별칭은 최대 10글자 입니다.")
+	@NotBlank(message = "주소별칭이 비어있으면 안됩니다.")
+	private final String addressAlias;
+
+	@Size(max = 50, message = "주소는 최대 50글자 입니다.")
+	@NotBlank(message = "주소는 비어있으면 안됩니다.")
+	private final String address;
+
+	public Address toEntity() {
+		return new Address(
+			addressAlias,
+			address
+		);
+	}
+}


### PR DESCRIPTION
## PR 확인 항목 
PR 보내기전에 아래 항목들을 만족 하였는지 체크 해주세요 

- [x] 곤모슬 팀에서 정한 커밋 메시지 규칙과 일치하는가?
- [x] 곤모슬 팀에서 정한 코딩 컨벤션과 일치하는가?

## PR 종류
어떤 종류의 PR인지 아래 항목중에 체크 해주세요
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 변경 (formatting, local variables)
- [ ] 리팩토링 (기능 변경 X)
- [ ] 빌드 관련 수정
- [ ] 문서 내용 수정
- [ ] 그 외, 어떤 종류인지 기입 바람:


## 어떤 기능이 추가 되었나요?
<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->
### Address

- attachTo(Member member)
    - address와 member는 다대일 양방향 관계로 묶여있으므로, 연관관계 편의 메소드를 구현했습니다.
    - 이미 Address의 필드로 member가 있다면, 기존 member의 address List에서 address를 지워주고
    새로운 member의 address list에 더해줍니다.
    - 혹시라도 새로운 member의 address list에, 새로 넣으려는 address가 이미 존재한다면 그냥 return합니다.
    - member의 addAddress메소드의 내부에서 호출되는 contains에서는 equals를 호출하므로, 요구사항 중 하나인 address의 주소값을 비교하기 위해 equals & hashcode를 상속받아 재정의해 주었습니다.
Issue Number: HIMIN-199


## 기존에 있던 기능에 영향을 주나요?

- [ ] 네
- [x] 아니요


<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


## 기타

