### PR TITLE
[HIMIN-115] feat: 요청 validation 예외 처리 추가

### DIFF
--- a/src/main/java/com/prgrms/himin/global/error/ErrorResponse.java
+++ b/src/main/java/com/prgrms/himin/global/error/ErrorResponse.java
@@ -1,22 +1,66 @@
 package com.prgrms.himin.global.error;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.validation.BindingResult;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.prgrms.himin.global.error.exception.ErrorCode;
 
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class ErrorResponse {
 
 	private final String error;
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private final List<FieldError> errors;
+
 	private final String code;
+
 	private final String message;
 
 	public static ErrorResponse from(ErrorCode errorCode) {
 		return new ErrorResponse(
 			errorCode.name(),
+			null,
 			errorCode.getCode(),
 			errorCode.getMessage()
 		);
+	}
+
+	public static ErrorResponse of(ErrorCode errorCode, BindingResult bindingResult) {
+		return new ErrorResponse(
+			errorCode.name(),
+			FieldError.from(bindingResult),
+			errorCode.getCode(),
+			errorCode.getMessage()
+		);
+	}
+
+	@Getter
+	@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+	public static class FieldError {
+
+		private final String field;
+		private final String value;
+		private final String reason;
+
+		private static List<FieldError> from(BindingResult bindingResult) {
+			List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+			return fieldErrors.stream()
+				.map(
+					error -> new FieldError(
+						error.getField(),
+						error.getRejectedValue() == null ? null : error.getRejectedValue().toString(),
+						error.getDefaultMessage()
+					))
+				.collect(Collectors.toList());
+		}
 	}
 }

--- a/src/main/java/com/prgrms/himin/global/error/ErrorResponse.java
+++ b/src/main/java/com/prgrms/himin/global/error/ErrorResponse.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.prgrms.himin.global.error.exception.ErrorCode;
@@ -19,7 +20,7 @@ public class ErrorResponse {
 	private final String error;
 
 	@JsonInclude(JsonInclude.Include.NON_NULL)
-	private final List<FieldError> errors;
+	private final List<FieldErrorResponse> errors;
 
 	private final String code;
 
@@ -37,7 +38,7 @@ public class ErrorResponse {
 	public static ErrorResponse of(ErrorCode errorCode, BindingResult bindingResult) {
 		return new ErrorResponse(
 			errorCode.name(),
-			FieldError.from(bindingResult),
+			FieldErrorResponse.from(bindingResult),
 			errorCode.getCode(),
 			errorCode.getMessage()
 		);
@@ -45,17 +46,17 @@ public class ErrorResponse {
 
 	@Getter
 	@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-	public static class FieldError {
+	public static class FieldErrorResponse {
 
 		private final String field;
 		private final String value;
 		private final String reason;
 
-		private static List<FieldError> from(BindingResult bindingResult) {
-			List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+		private static List<FieldErrorResponse> from(BindingResult bindingResult) {
+			List<FieldError> fieldErrors = bindingResult.getFieldErrors();
 			return fieldErrors.stream()
 				.map(
-					error -> new FieldError(
+					error -> new FieldErrorResponse(
 						error.getField(),
 						error.getRejectedValue() == null ? null : error.getRejectedValue().toString(),
 						error.getDefaultMessage()

--- a/src/main/java/com/prgrms/himin/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/prgrms/himin/global/error/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.prgrms.himin.global.error;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -20,6 +22,14 @@ public class GlobalExceptionHandler {
 		log.error("UnExpected Exception", e);
 		ErrorResponse response = ErrorResponse.from(ErrorCode.INTERNAL_SERVER_ERROR);
 		return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+		log.error("MethodArgumentNotValidException Exception", e);
+		BindingResult bindingResult = e.getBindingResult();
+		ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_REQUEST, bindingResult);
+		return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
 	}
 
 	@ExceptionHandler(EntityNotFoundException.class)

--- a/src/main/java/com/prgrms/himin/global/error/exception/ErrorCode.java
+++ b/src/main/java/com/prgrms/himin/global/error/exception/ErrorCode.java
@@ -9,6 +9,7 @@ public enum ErrorCode {
 
 	// Common
 	INTERNAL_SERVER_ERROR("COMMON_001", "Internal Server Error"),
+	INVALID_REQUEST("COMMON_002", "유효하지 않은 요청입니다."),
 
 	// Member
 	MEMBER_NOT_FOUND("MEMBER_001", "회원을 찾을 수 없습니다.");


### PR DESCRIPTION
## PR 확인 항목 
PR 보내기전에 아래 항목들을 만족 하였는지 체크 해주세요 

- [x] 곤모슬 팀에서 정한 커밋 메시지 규칙과 일치하는가?
- [x] 곤모슬 팀에서 정한 코딩 컨벤션과 일치하는가?

## PR 종류
어떤 종류의 PR인지 아래 항목중에 체크 해주세요
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 변경 (formatting, local variables)
- [ ] 리팩토링 (기능 변경 X)
- [ ] 빌드 관련 수정
- [ ] 문서 내용 수정
- [ ] 그 외, 어떤 종류인지 기입 바람:


## 어떤 기능이 추가 되었나요?
<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### MethodArgumentNotValidException 예외 처리 추가
- RequestDto에서 검증 실패하면 MethodArgumentNotValidException 예외가 터집니다.
- 이 예외는 BindingResult 를 가지고 있는데 이것은 검증 오류에 대한 내용을 담고 있습니다. 여기서 실패한 검증에 대한 내용들을 추출해내 예외 응답으로 출력하도록 합니다.
- 검증 오류가 아닌 경우도 있기 때문에 관련 필드에 `@JsonInclude(JsonInclude.Include.NON_NULL)`를 붙여주어 null 인 경우 응답에서 제외하도록 구현하였습니다.

Issue Number: HIMIN-115


## 기존에 있던 기능에 영향을 주나요?

- [ ] 네
- [x] 아니요


<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


## 기타

