### PR TITLE
[HIMIN-155] refactor : 회원 주소 조회 할 경우 내부적으로 쿼리 2회에서 1회로 해결할 수 있도록 리팩터링

### DIFF
--- a/src/main/java/com/prgrms/himin/member/application/MemberService.java
+++ b/src/main/java/com/prgrms/himin/member/application/MemberService.java
@@ -113,11 +113,7 @@ public class MemberService {
 	}
 
 	public List<AddressResponse> getAllAddress(Long memberId) {
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow(
-				() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND)
-			);
-		List<Address> addresses = member.getAddresses();
+		List<Address> addresses = addressRepository.findAddressesByMemberId(memberId);
 		List<AddressResponse> addressResponses = addresses.stream()
 			.map(AddressResponse::from)
 			.toList();

--- a/src/main/java/com/prgrms/himin/member/domain/AddressRepository.java
+++ b/src/main/java/com/prgrms/himin/member/domain/AddressRepository.java
@@ -1,6 +1,12 @@
 package com.prgrms.himin.member.domain;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface AddressRepository extends JpaRepository<Address, Long> {
+
+	@Query("select a from Address a where a.member.id = :memberId")
+	List<Address> findAddressesByMemberId(Long memberId);
 }


### PR DESCRIPTION
## PR 확인 항목 
PR 보내기전에 아래 항목들을 만족 하였는지 체크 해주세요 

- [x] 곤모슬 팀에서 정한 커밋 메시지 규칙과 일치하는가?
- [x] 곤모슬 팀에서 정한 코딩 컨벤션과 일치하는가?

## PR 종류
어떤 종류의 PR인지 아래 항목중에 체크 해주세요
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 변경 (formatting, local variables)
- [x] 리팩토링 (기능 변경 X)
- [ ] 빌드 관련 수정
- [ ] 문서 내용 수정
- [ ] 테스트 추가
- [ ] 그 외, 어떤 종류인지 기입 바람:


## 어떤 기능이 추가 되었나요?
<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->
### 회원 주소 조회 할 경우 내부적으로 쿼리 2회에서 1회로 해결할 수 있도록 리팩터링
- member_id로 주소 조회할 경우 내부적으로 2번 쿼리 실행 
- address repository에서 custom query를 이용하여 1회 쿼리 실행으로 주소를 가져올 수 있도록 리팩터링 

Issue Number: HIMIN-155


## 기존에 있던 기능에 영향을 주나요?

- [ ] 네
- [x] 아니요


<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


## 기타

