### PR TITLE
[HIMIN-176] feat : 커서 방식의 주문 조회 기능 구현

### DIFF
--- a/src/main/java/com/prgrms/himin/order/api/OrderController.java
+++ b/src/main/java/com/prgrms/himin/order/api/OrderController.java
@@ -16,8 +16,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.prgrms.himin.order.application.OrderService;
 import com.prgrms.himin.order.dto.request.OrderCreateRequest;
 import com.prgrms.himin.order.dto.request.OrderSearchCondition;
-import com.prgrms.himin.order.dto.response.OrderListResponse;
 import com.prgrms.himin.order.dto.response.OrderResponse;
+import com.prgrms.himin.order.dto.response.OrderResponses;
 
 import lombok.RequiredArgsConstructor;
 
@@ -43,13 +43,13 @@ public class OrderController {
 	}
 
 	@GetMapping("/list")
-	private ResponseEntity<OrderListResponse> getOrders(
+	private ResponseEntity<OrderResponses> getOrders(
 		@RequestHeader("member-id") Long memberId,
 		@ModelAttribute OrderSearchCondition orderSearchCondition,
 		@RequestParam(required = false, defaultValue = "10") int size,
 		@RequestParam(required = false) Long cursor
 	) {
-		OrderListResponse responses = orderService.getOrders(
+		OrderResponses responses = orderService.getOrders(
 			memberId,
 			orderSearchCondition,
 			size,

--- a/src/main/java/com/prgrms/himin/order/api/OrderController.java
+++ b/src/main/java/com/prgrms/himin/order/api/OrderController.java
@@ -4,14 +4,19 @@ import javax.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.prgrms.himin.order.application.OrderService;
 import com.prgrms.himin.order.dto.request.OrderCreateRequest;
+import com.prgrms.himin.order.dto.request.OrderSearchCondition;
+import com.prgrms.himin.order.dto.response.OrderListResponse;
 import com.prgrms.himin.order.dto.response.OrderResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -35,5 +40,22 @@ public class OrderController {
 		OrderResponse response = orderService.getOrder(orderId);
 
 		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/list")
+	private ResponseEntity<OrderListResponse> getOrders(
+		@RequestHeader("member-id") Long memberId,
+		@ModelAttribute OrderSearchCondition orderSearchCondition,
+		@RequestParam(required = false, defaultValue = "10") int size,
+		@RequestParam(required = false) Long cursor
+	) {
+		OrderListResponse responses = orderService.getOrders(
+			memberId,
+			orderSearchCondition,
+			size,
+			cursor
+		);
+
+		return ResponseEntity.ok(responses);
 	}
 }

--- a/src/main/java/com/prgrms/himin/order/application/OrderService.java
+++ b/src/main/java/com/prgrms/himin/order/application/OrderService.java
@@ -248,7 +248,7 @@ public class OrderService {
 		int size
 	) {
 		if (orders.isEmpty()) {
-			Order lastOrder = orderRepository.findFirstByMember_IdOrderByOrderIdDesc(memberId);
+			Order lastOrder = orderRepository.findFirstByMemberIdOrderByOrderIdDesc(memberId);
 			if (lastOrder == null) {
 				return null;
 			}

--- a/src/main/java/com/prgrms/himin/order/application/OrderService.java
+++ b/src/main/java/com/prgrms/himin/order/application/OrderService.java
@@ -24,8 +24,10 @@ import com.prgrms.himin.order.domain.OrderItem;
 import com.prgrms.himin.order.domain.OrderRepository;
 import com.prgrms.himin.order.domain.SelectedOption;
 import com.prgrms.himin.order.dto.request.OrderCreateRequest;
+import com.prgrms.himin.order.dto.request.OrderSearchCondition;
 import com.prgrms.himin.order.dto.request.SelectedMenuOptionRequest;
 import com.prgrms.himin.order.dto.request.SelectedMenuRequest;
+import com.prgrms.himin.order.dto.response.OrderListResponse;
 import com.prgrms.himin.order.dto.response.OrderResponse;
 import com.prgrms.himin.shop.domain.Shop;
 import com.prgrms.himin.shop.domain.ShopRepository;
@@ -201,5 +203,36 @@ public class OrderService {
 		}
 
 		return menuOptions;
+	}
+
+	private boolean isLast(List<Order> orders, int size) {
+		return orders.size() <= size;
+	}
+
+	public OrderListResponse getOrders(
+		Long memberId,
+		OrderSearchCondition orderSearchCondition,
+		int size,
+		Long cursor
+	) {
+		List<Order> orders = orderRepository.searchOrders(
+			memberId,
+			orderSearchCondition,
+			size,
+			cursor
+		);
+
+		return new OrderListResponse(
+			getOrderResponses(orders),
+			size,
+			cursor,
+			isLast(orders, size)
+		);
+	}
+
+	private List<OrderResponse> getOrderResponses(List<Order> orders) {
+		return orders.stream()
+			.map(OrderResponse::from)
+			.toList();
 	}
 }

--- a/src/main/java/com/prgrms/himin/order/application/OrderService.java
+++ b/src/main/java/com/prgrms/himin/order/application/OrderService.java
@@ -27,8 +27,8 @@ import com.prgrms.himin.order.dto.request.OrderCreateRequest;
 import com.prgrms.himin.order.dto.request.OrderSearchCondition;
 import com.prgrms.himin.order.dto.request.SelectedMenuOptionRequest;
 import com.prgrms.himin.order.dto.request.SelectedMenuRequest;
-import com.prgrms.himin.order.dto.response.OrderListResponse;
 import com.prgrms.himin.order.dto.response.OrderResponse;
+import com.prgrms.himin.order.dto.response.OrderResponses;
 import com.prgrms.himin.shop.domain.Shop;
 import com.prgrms.himin.shop.domain.ShopRepository;
 
@@ -217,7 +217,7 @@ public class OrderService {
 		return orders.size() <= size;
 	}
 
-	public OrderListResponse getOrders(
+	public OrderResponses getOrders(
 		Long memberId,
 		OrderSearchCondition orderSearchCondition,
 		int size,
@@ -230,7 +230,7 @@ public class OrderService {
 			cursor
 		);
 
-		return new OrderListResponse(
+		return new OrderResponses(
 			getOrderResponses(orders),
 			size,
 			getNextCursor(

--- a/src/main/java/com/prgrms/himin/order/domain/OrderRepository.java
+++ b/src/main/java/com/prgrms/himin/order/domain/OrderRepository.java
@@ -2,5 +2,5 @@ package com.prgrms.himin.order.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface OrderRepository extends JpaRepository<Order, Long> {
+public interface OrderRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
 }

--- a/src/main/java/com/prgrms/himin/order/domain/OrderRepository.java
+++ b/src/main/java/com/prgrms/himin/order/domain/OrderRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
 
-	Order findFirstByMember_IdOrderByOrderIdDesc(Long member_id);
+	Order findFirstByMemberIdOrderByOrderIdDesc(Long member_id);
 }

--- a/src/main/java/com/prgrms/himin/order/domain/OrderRepository.java
+++ b/src/main/java/com/prgrms/himin/order/domain/OrderRepository.java
@@ -3,4 +3,6 @@ package com.prgrms.himin.order.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
+
+	Order findFirstByMember_IdOrderByOrderIdDesc(Long member_id);
 }

--- a/src/main/java/com/prgrms/himin/order/domain/OrderRepositoryCustom.java
+++ b/src/main/java/com/prgrms/himin/order/domain/OrderRepositoryCustom.java
@@ -1,0 +1,15 @@
+package com.prgrms.himin.order.domain;
+
+import java.util.List;
+
+import com.prgrms.himin.order.dto.request.OrderSearchCondition;
+
+public interface OrderRepositoryCustom {
+
+	List<Order> searchOrders(
+		Long memberId,
+		OrderSearchCondition orderSearchCondition,
+		int size,
+		Long cursor
+	);
+}

--- a/src/main/java/com/prgrms/himin/order/domain/OrderRepositoryImpl.java
+++ b/src/main/java/com/prgrms/himin/order/domain/OrderRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.prgrms.himin.order.domain;
+
+import static com.prgrms.himin.order.domain.QOrder.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.prgrms.himin.order.dto.request.OrderSearchCondition;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderRepositoryImpl implements OrderRepositoryCustom {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	@Override
+	public List<Order> searchOrders(
+		Long memberId,
+		OrderSearchCondition orderSearchCondition,
+		int size,
+		Long cursor
+	) {
+		return jpaQueryFactory
+			.selectFrom(order)
+			.where(
+				order.member.id.eq(memberId),
+				greaterThanCursor(cursor)
+			)
+			.limit(size + 1)
+			.fetch();
+	}
+
+	private Predicate greaterThanCursor(Long cursor) {
+		return cursor != null ? order.orderId.gt(cursor) : null;
+	}
+}

--- a/src/main/java/com/prgrms/himin/order/dto/request/OrderSearchCondition.java
+++ b/src/main/java/com/prgrms/himin/order/dto/request/OrderSearchCondition.java
@@ -1,0 +1,18 @@
+package com.prgrms.himin.order.dto.request;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.prgrms.himin.order.domain.OrderStatus;
+import com.prgrms.himin.shop.domain.Category;
+
+public class OrderSearchCondition {
+
+	List<Category> categories;
+
+	List<OrderStatus> orderStatuses;
+
+	LocalDateTime startTime;
+
+	LocalDateTime EndTime;
+}

--- a/src/main/java/com/prgrms/himin/order/dto/response/OrderListResponse.java
+++ b/src/main/java/com/prgrms/himin/order/dto/response/OrderListResponse.java
@@ -1,0 +1,15 @@
+package com.prgrms.himin.order.dto.response;
+
+import java.util.List;
+
+public record OrderListResponse(
+
+	List<OrderResponse> orderResponses,
+
+	int size,
+
+	Long nextCursor,
+
+	boolean isLast
+) {
+}

--- a/src/main/java/com/prgrms/himin/order/dto/response/OrderResponses.java
+++ b/src/main/java/com/prgrms/himin/order/dto/response/OrderResponses.java
@@ -2,7 +2,7 @@ package com.prgrms.himin.order.dto.response;
 
 import java.util.List;
 
-public record OrderListResponse(
+public record OrderResponses(
 
 	List<OrderResponse> orderResponses,
 


### PR DESCRIPTION
## PR 확인 항목 
PR 보내기전에 아래 항목들을 만족 하였는지 체크 해주세요 

- [x] 곤모슬 팀에서 정한 커밋 메시지 규칙과 일치하는가?
- [x] 곤모슬 팀에서 정한 코딩 컨벤션과 일치하는가?

## PR 종류
어떤 종류의 PR인지 아래 항목중에 체크 해주세요
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 변경 (formatting, local variables)
- [ ] 리팩토링 (기능 변경 X)
- [ ] 빌드 관련 수정
- [ ] 문서 내용 수정
- [ ] 테스트 추가
- [ ] 그 외, 어떤 종류인지 기입 바람:


## 어떤 기능이 추가 되었나요?
<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### 커서 방식의 주문 조회 기능 구현
- 헤더의 멤버 아이디와 일치하는 주문 조회 
헤더를 사용한 이유는 아래 노션 페이지에 정리하였는데 참고 바랍니다!
[주문 조회 파라미터는 왜 헤더를 통해 아이디를 받을까?](https://www.notion.so/backend-devcourse/4817e8f3b51f45c6b3df19a11b568037?pvs=4)

- 페이지네이션을 커서 방식으로 구현 하였습니다! 

Issue Number: HIMIN-176


## 기존에 있던 기능에 영향을 주나요?

- [ ] 네
- [x] 아니요


<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


## 기타

