### PR TITLE
[HIMIN-176] feat : 주문 검색할 경우 fetch join 기능 추가 및 검색 가능 옵션 추가

### DIFF
--- a/src/main/java/com/prgrms/himin/order/domain/OrderRepositoryImpl.java
+++ b/src/main/java/com/prgrms/himin/order/domain/OrderRepositoryImpl.java
@@ -1,13 +1,19 @@
 package com.prgrms.himin.order.domain;
 
 import static com.prgrms.himin.order.domain.QOrder.*;
+import static com.prgrms.himin.order.domain.QOrderHistory.*;
+import static com.prgrms.himin.order.domain.QOrderItem.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
 import com.prgrms.himin.order.dto.request.OrderSearchCondition;
+import com.prgrms.himin.shop.domain.Category;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -26,16 +32,58 @@ public class OrderRepositoryImpl implements OrderRepositoryCustom {
 		Long cursor
 	) {
 		return jpaQueryFactory
-			.selectFrom(order)
+			.select(order)
+			.from(order)
 			.where(
-				order.member.id.eq(memberId),
+				equalCategory(orderSearchCondition.categories()),
+				equalOrderStatus(orderSearchCondition.orderStatuses()),
+				betweenTime(orderSearchCondition.startTime(), orderSearchCondition.endTime()),
 				greaterThanCursor(cursor)
 			)
+			.leftJoin(orderHistory).on(orderHistory.order.eq(order)) // fetch가 아니라 필터 하기 위한 join
+			.leftJoin(order.orderItems, orderItem)
+			.fetchJoin()
 			.limit(size + 1)
 			.fetch();
 	}
 
 	private Predicate greaterThanCursor(Long cursor) {
 		return cursor != null ? order.orderId.gt(cursor) : null;
+	}
+
+	private BooleanExpression betweenTime(LocalDateTime start, LocalDateTime end) {
+		if (start == null || end == null) {
+			return null;
+		}
+
+		return order.orderTime.between(start, end);
+	}
+
+	private BooleanBuilder equalCategory(List<Category> categories) {
+		if (categories == null) {
+			return null;
+		}
+
+		BooleanBuilder booleanBuilder = new BooleanBuilder();
+
+		for (Category category : categories) {
+			booleanBuilder.or(order.shop.category.eq(category));
+		}
+
+		return booleanBuilder;
+	}
+
+	private BooleanBuilder equalOrderStatus(List<OrderStatus> orderStatuses) {
+		if (orderStatuses == null) {
+			return null;
+		}
+
+		BooleanBuilder booleanBuilder = new BooleanBuilder();
+
+		for (OrderStatus orderStatus : orderStatuses) {
+			booleanBuilder.or(orderHistory.orderStatus.eq(orderStatus));
+		}
+
+		return booleanBuilder;
 	}
 }

--- a/src/main/java/com/prgrms/himin/order/dto/request/OrderSearchCondition.java
+++ b/src/main/java/com/prgrms/himin/order/dto/request/OrderSearchCondition.java
@@ -6,13 +6,14 @@ import java.util.List;
 import com.prgrms.himin.order.domain.OrderStatus;
 import com.prgrms.himin.shop.domain.Category;
 
-public class OrderSearchCondition {
+public record OrderSearchCondition(
 
-	List<Category> categories;
+	List<Category> categories,
 
-	List<OrderStatus> orderStatuses;
+	List<OrderStatus> orderStatuses,
 
-	LocalDateTime startTime;
+	LocalDateTime startTime,
 
-	LocalDateTime EndTime;
+	LocalDateTime endTime
+) {
 }


### PR DESCRIPTION
## PR 확인 항목 
PR 보내기전에 아래 항목들을 만족 하였는지 체크 해주세요 

- [x] 곤모슬 팀에서 정한 커밋 메시지 규칙과 일치하는가?
- [x] 곤모슬 팀에서 정한 코딩 컨벤션과 일치하는가?

## PR 종류
어떤 종류의 PR인지 아래 항목중에 체크 해주세요
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 변경 (formatting, local variables)
- [ ] 리팩토링 (기능 변경 X)
- [ ] 빌드 관련 수정
- [ ] 문서 내용 수정
- [ ] 테스트 추가
- [ ] 그 외, 어떤 종류인지 기입 바람:


## 어떤 기능이 추가 되었나요?
<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->
### 주문 검색 기능 추가
- fetch join을 활용하여 N+1 문제로 인해 다수의 쿼리가 나가는것을 줄이려고 노력 
- One To Many 관계가 두개 이상이여서 order item한 곳에만  fetch join 적용 
- 나머지는 배치 사이즈를 조절하여 추가적으로 하나의 쿼리가 나가도록 적용 
- 이후 필요하다면 OrderRepositoryImpl에 있는 searchOrders의 반환을 dto로 변경하여 최적화할 계획

Issue Number: HIMIN-176


## 기존에 있던 기능에 영향을 주나요?

- [ ] 네
- [x] 아니요


<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


## 기타

