### PR TITLE
[HIMIN-218] test : 회원 생성 테스트 구현

### DIFF
--- a/src/test/java/com/prgrms/himin/member/application/MemberServiceTest.java
+++ b/src/test/java/com/prgrms/himin/member/application/MemberServiceTest.java
@@ -1,0 +1,67 @@
+package com.prgrms.himin.member.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.prgrms.himin.member.domain.Member;
+import com.prgrms.himin.member.domain.MemberRepository;
+import com.prgrms.himin.member.dto.request.MemberCreateRequest;
+import com.prgrms.himin.member.dto.response.MemberCreateResponse;
+import com.prgrms.himin.setup.request.MemberCreateRequestBuilder;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+	@Mock
+	MemberRepository memberRepository;
+
+	@InjectMocks
+	MemberService memberService;
+
+	@Mock
+	PasswordEncoder passwordEncoder;
+
+	Member member;
+
+	MemberCreateRequest request;
+
+	@BeforeEach
+	void setup() {
+		request = MemberCreateRequestBuilder.successBuild();
+
+		given(passwordEncoder.encode(request.password()))
+			.willReturn(request.password());
+
+		String password = passwordEncoder.encode(request.password());
+		member = request.toEntity(password);
+	}
+
+	@DisplayName("회원 생성을 할 수 있다.")
+	@Nested
+	class CreateMember {
+
+		@DisplayName("성공한다.")
+		@Test
+		void success_test() {
+			// given
+			given(memberRepository.save(any(Member.class))).willReturn(member);
+
+			// when
+			MemberCreateResponse actual = memberService.createMember(request);
+
+			// then
+			MemberCreateResponse expected = MemberCreateResponse.from(member);
+			assertThat(actual).usingRecursiveComparison().isEqualTo(expected);
+		}
+	}
+}

--- a/src/test/java/com/prgrms/himin/member/application/MemberServiceTest.java
+++ b/src/test/java/com/prgrms/himin/member/application/MemberServiceTest.java
@@ -38,12 +38,6 @@ class MemberServiceTest {
 	@BeforeEach
 	void setup() {
 		request = MemberCreateRequestBuilder.successBuild();
-
-		given(passwordEncoder.encode(request.password()))
-			.willReturn(request.password());
-
-		String password = passwordEncoder.encode(request.password());
-		member = request.toEntity(password);
 	}
 
 	@DisplayName("회원 생성을 할 수 있다.")
@@ -54,6 +48,10 @@ class MemberServiceTest {
 		@Test
 		void success_test() {
 			// given
+			String password = "$2a$12$5JSVlqKP/gghOclI/Y053OX9rJDzNDBwUBI6RcWXG5/xRGfbflIW6";
+			given(passwordEncoder.encode(anyString())).willReturn(password);
+
+			member = request.toEntity(password);
 			given(memberRepository.save(any(Member.class))).willReturn(member);
 
 			// when


### PR DESCRIPTION
## PR 확인 항목 
PR 보내기전에 아래 항목들을 만족 하였는지 체크 해주세요 

- [x] 곤모슬 팀에서 정한 커밋 메시지 규칙과 일치하는가?
- [x] 곤모슬 팀에서 정한 코딩 컨벤션과 일치하는가?

## PR 종류
어떤 종류의 PR인지 아래 항목중에 체크 해주세요
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 변경 (formatting, local variables)
- [ ] 리팩토링 (기능 변경 X)
- [ ] 빌드 관련 수정
- [ ] 문서 내용 수정
- [x] 테스트 추가
- [ ] 그 외, 어떤 종류인지 기입 바람:


## 어떤 기능이 추가 되었나요?
<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->
회원 생성 테스트 구현

Issue Number: HIMIN-218


## 기존에 있던 기능에 영향을 주나요?

- [ ] 네
- [x] 아니요


<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


## 기타
회원 테스트 작성 중 passWordEncoder의 stub을 지정해 줄 때, willReturn에 anyString()을 써 줄지, 다른 임의의 값을 써 줄지 고민하다 일단은 Service 테스트에 영향을 끼치는 값이 아니라고 판단되어, request로 들어온 password를 그대로 return하도록 했습니다.
팀원분들 생각에는 willReturn에 어느 값을 적는 것이 좋다고 생각하시는지 궁금합니다 !
