### PR TITLE
[HIMIN-232] refactor: 회원 비밀번호 검증 후 비번 암호화

### DIFF
--- a/src/main/java/com/prgrms/himin/member/application/MemberService.java
+++ b/src/main/java/com/prgrms/himin/member/application/MemberService.java
@@ -89,9 +89,11 @@ public class MemberService {
 				() -> new EntityNotFoundException(ErrorCode.MEMBER_NOT_FOUND)
 			);
 
+		String encodedPassword = passwordEncoder.encode(request.password());
+
 		member.updateInfo(
 			request.loginId(),
-			request.password(),
+			Member.password(request.password(), encodedPassword),
 			request.name(),
 			request.phone(),
 			request.birthday()

--- a/src/main/java/com/prgrms/himin/member/domain/Member.java
+++ b/src/main/java/com/prgrms/himin/member/domain/Member.java
@@ -42,6 +42,8 @@ public class Member {
 
 	public static final int PASSWORD_MAX_LENGTH = 20;
 
+	private static final int ENCODED_PASSWORD_LENGTH = 60;
+
 	public static final int NAME_MAX_LENGTH = 10;
 
 	public static final int PHONE_MAX_LENGTH = 15;
@@ -54,7 +56,7 @@ public class Member {
 	@Column(name = "login_id", nullable = false, length = ID_MAX_LENGTH)
 	private String loginId;
 
-	@Column(name = "password", nullable = false, length = PASSWORD_MAX_LENGTH)
+	@Column(name = "password", nullable = false, length = ENCODED_PASSWORD_LENGTH)
 	private String password;
 
 	@Column(name = "name", nullable = false, length = NAME_MAX_LENGTH)

--- a/src/main/java/com/prgrms/himin/member/domain/Member.java
+++ b/src/main/java/com/prgrms/himin/member/domain/Member.java
@@ -40,7 +40,7 @@ public class Member {
 
 	public static final int ID_MAX_LENGTH = 20;
 
-	public static final int PASSWORD_MAX_LENGTH = 60;
+	public static final int PASSWORD_MAX_LENGTH = 20;
 
 	public static final int NAME_MAX_LENGTH = 10;
 
@@ -85,7 +85,6 @@ public class Member {
 		LocalDate birthday
 	) {
 		validateLoginId(loginId);
-		validatePassword(password);
 		validateName(name);
 		validatePhone(phone);
 		validateBirthDay(birthday);
@@ -96,6 +95,11 @@ public class Member {
 		this.birthday = birthday;
 		this.grade = Grade.NEW;
 		this.roles.add(Permission.ROLE_USER.name());
+	}
+
+	public static String password(String password, String encodedPassword) {
+		validatePassword(password);
+		return encodedPassword;
 	}
 
 	public void updateGrade(Grade grade) {
@@ -139,7 +143,6 @@ public class Member {
 		LocalDate birthday
 	) {
 		validateLoginId(loginId);
-		validatePassword(password);
 		validateName(name);
 		validatePhone(phone);
 		validateBirthDay(birthday);
@@ -156,7 +159,7 @@ public class Member {
 		}
 	}
 
-	private void validatePassword(String password) {
+	private static void validatePassword(String password) {
 		if (password == null || password.length() > PASSWORD_MAX_LENGTH) {
 			throw new InvalidValueException(ErrorCode.MEMBER_PASSWORD_BAD_REQUEST);
 		}

--- a/src/main/java/com/prgrms/himin/member/dto/request/MemberCreateRequest.java
+++ b/src/main/java/com/prgrms/himin/member/dto/request/MemberCreateRequest.java
@@ -43,10 +43,10 @@ public record MemberCreateRequest(
 	String address
 ) {
 
-	public Member toEntity(String password) {
+	public Member toEntity(String encodedPassword) {
 		return Member.builder()
 			.loginId(loginId)
-			.password(password)
+			.password(Member.password(password, encodedPassword))
 			.name(name)
 			.phone(phone)
 			.birthday(birthday)

--- a/src/test/java/com/prgrms/himin/member/api/MemberControllerTest.java
+++ b/src/test/java/com/prgrms/himin/member/api/MemberControllerTest.java
@@ -268,7 +268,6 @@ class MemberControllerTest {
 				.andDo(print());
 
 			assertThat(updatedMember.getLoginId()).isEqualTo(request.loginId());
-			assertThat(updatedMember.getPassword()).isEqualTo(request.password());
 			assertThat(updatedMember.getName()).isEqualTo(request.name());
 			assertThat(updatedMember.getPhone()).isEqualTo(request.phone());
 			assertThat(updatedMember.getBirthday()).isEqualTo(request.birthday());

--- a/src/test/java/com/prgrms/himin/member/application/MemberServiceTest.java
+++ b/src/test/java/com/prgrms/himin/member/application/MemberServiceTest.java
@@ -192,8 +192,10 @@ class MemberServiceTest {
 				.findById(member.getId()).get();
 
 			assertThat(request).usingRecursiveComparison()
-				.ignoringFields("addresses")
+				.ignoringFields("password", "addresses")
 				.isEqualTo(actual);
+			boolean result = passwordEncoder.matches(request.password(), actual.getPassword());
+			assertThat(result).isTrue();
 		}
 
 		@DisplayName("회원id가 잘못되어 실패한다.")


### PR DESCRIPTION
## PR 확인 항목 
PR 보내기전에 아래 항목들을 만족 하였는지 체크 해주세요 

- [x] 곤모슬 팀에서 정한 커밋 메시지 규칙과 일치하는가?
- [x] 곤모슬 팀에서 정한 코딩 컨벤션과 일치하는가?

## PR 종류
어떤 종류의 PR인지 아래 항목중에 체크 해주세요
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [x] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 변경 (formatting, local variables)
- [x] 리팩토링 (기능 변경 X)
- [ ] 빌드 관련 수정
- [ ] 문서 내용 수정
- [ ] 테스트 추가
- [ ] 그 외, 어떤 종류인지 기입 바람:


## 어떤 기능이 추가 되었나요?
<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

이전에는 서비스단에서 비밀번호를 암호화한 값을 Member에 넘겨주었습니다. 하지만 이 방식에 문제가 있다는 것을 발견했습니다. 바로 비밀번호 길이에 대한 검증을 제외한 나머지 검증을 하지 못한다는 것이었습니다.

실제로 bcrypt 생성 사이트에서 실험해본 결과, 아무것도 입력하지 않을 때와 공백이 입력될 때 모두 bcrypt로 암호화되었습니다. 이 말은 공백에 대해서는 검증을 하지 못한다는 말입니다.

그래서 `Member.passwor(...)` 라는 정적 메서드를 만들었습니다. 이 메서드에서 비밀번호를 검증하고 통과한다면 암호화된 비밀번호를 반환하도록 하여, 회원 생성과 업데이트 시 해당 메서드를 사용하도록 변경하였습니다.

Issue Number: HIMIN-232


## 기존에 있던 기능에 영향을 주나요?

- [ ] 네
- [x] 아니요


<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


## 기타

