### PR TITLE
[HIMIN-234] refactor : delivery생성시 orderId validation 추가

### DIFF
--- a/src/main/java/com/prgrms/himin/delivery/application/DeliveryService.java
+++ b/src/main/java/com/prgrms/himin/delivery/application/DeliveryService.java
@@ -17,6 +17,7 @@ import com.prgrms.himin.delivery.dto.response.DeliveryResponse;
 import com.prgrms.himin.global.error.exception.BusinessException;
 import com.prgrms.himin.global.error.exception.EntityNotFoundException;
 import com.prgrms.himin.global.error.exception.ErrorCode;
+import com.prgrms.himin.order.domain.OrderValidator;
 import com.prgrms.himin.order.event.DeliveryFinishedEvent;
 
 import lombok.RequiredArgsConstructor;
@@ -34,8 +35,12 @@ public class DeliveryService {
 
 	private final ApplicationEventPublisher publisher;
 
+	private final OrderValidator orderValidator;
+
 	@Transactional
 	public DeliveryResponse createDelivery(Long orderId) {
+		orderValidator.validateOrderId(orderId);
+
 		Delivery delivery = new Delivery(orderId);
 		Delivery savedDelivery = deliveryRepository.save(delivery);
 

--- a/src/main/java/com/prgrms/himin/order/domain/OrderValidator.java
+++ b/src/main/java/com/prgrms/himin/order/domain/OrderValidator.java
@@ -1,0 +1,21 @@
+package com.prgrms.himin.order.domain;
+
+import org.springframework.stereotype.Component;
+
+import com.prgrms.himin.global.error.exception.EntityNotFoundException;
+import com.prgrms.himin.global.error.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class OrderValidator {
+
+	private final OrderRepository orderRepository;
+
+	public void validateOrderId(Long orderId) {
+		if (!orderRepository.existsById(orderId)) {
+			throw new EntityNotFoundException(ErrorCode.ORDER_NOT_FOUND);
+		}
+	}
+}


### PR DESCRIPTION
## PR 확인 항목 
PR 보내기전에 아래 항목들을 만족 하였는지 체크 해주세요 

- [x] 곤모슬 팀에서 정한 커밋 메시지 규칙과 일치하는가?
- [x] 곤모슬 팀에서 정한 코딩 컨벤션과 일치하는가?

## PR 종류
어떤 종류의 PR인지 아래 항목중에 체크 해주세요
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ] 버그 수정
- [x] 기능 추가
- [ ] 코드 스타일 변경 (formatting, local variables)
- [ ] 리팩토링 (기능 변경 X)
- [ ] 빌드 관련 수정
- [ ] 문서 내용 수정
- [x] 테스트 추가
- [ ] 그 외, 어떤 종류인지 기입 바람:


## 어떤 기능이 추가 되었나요?
<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->
delivery생성시 orderId validation 추가

Issue Number: HIMIN-234, HIMIN-235


## 기존에 있던 기능에 영향을 주나요?

- [x] 네
- [ ] 아니요


<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->
Delivery생성시 인자로 받는 orderId가 실제로 존재하는지 검증합니다.

## 기타
orderId를 검증하기 위해 OrderValidator를 만드는 과정에서 생긴 고민 정리 : https://www.notion.so/backend-devcourse/Delivery-OrderId-Validation-8c48748722f04ad6bc09cc7ce23dda04?pvs=4
orderId Validation중 만났던 트러블 슈팅 : 
1 : https://www.notion.so/backend-devcourse/Autowired-InjectMocks-09c7a2c386e74b6d83efbdbffa0d99a0?pvs=4
2 : https://www.notion.so/backend-devcourse/MockBean-stubbing-017c78fc547247509bda14fb7cca7059?pvs=4