### PR TITLE
[HIMIN-236] fix : finishDelivery 트랜잭션 분리 -> 결합

### DIFF
--- a/src/main/java/com/prgrms/himin/order/event/OrderEventHandler.java
+++ b/src/main/java/com/prgrms/himin/order/event/OrderEventHandler.java
@@ -1,12 +1,7 @@
 package com.prgrms.himin.order.event;
 
-import static org.springframework.transaction.annotation.Propagation.*;
-
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.prgrms.himin.order.application.OrderService;
 
@@ -18,11 +13,7 @@ public class OrderEventHandler {
 
 	private final OrderService orderService;
 
-	@Transactional(propagation = REQUIRES_NEW)
-	@TransactionalEventListener(
-		classes = DeliveryFinishedEvent.class,
-		phase = TransactionPhase.AFTER_COMMIT
-	)
+	@EventListener(classes = DeliveryFinishedEvent.class)
 	public void finishOrder(DeliveryFinishedEvent event) {
 		orderService.finishOrder(event.getOrderId());
 	}

--- a/src/test/java/com/prgrms/himin/delivery/application/DeliveryServiceTest.java
+++ b/src/test/java/com/prgrms/himin/delivery/application/DeliveryServiceTest.java
@@ -5,6 +5,8 @@ import static org.mockito.Mockito.*;
 
 import java.util.List;
 
+import javax.transaction.Transactional;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -13,7 +15,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.prgrms.himin.delivery.domain.Delivery;
 import com.prgrms.himin.delivery.domain.DeliveryHistory;
@@ -26,6 +27,7 @@ import com.prgrms.himin.delivery.dto.response.DeliveryHistoryResponse;
 import com.prgrms.himin.delivery.dto.response.DeliveryResponse;
 import com.prgrms.himin.global.error.exception.BusinessException;
 import com.prgrms.himin.global.error.exception.EntityNotFoundException;
+import com.prgrms.himin.order.application.OrderService;
 import com.prgrms.himin.order.domain.OrderValidator;
 import com.prgrms.himin.setup.domain.DeliverySetUp;
 import com.prgrms.himin.setup.domain.RiderSetUp;
@@ -61,6 +63,9 @@ class DeliveryServiceTest {
 
 	@SpyBean
 	OrderValidator orderValidator;
+
+	@SpyBean
+	OrderService orderService;
 
 	@BeforeEach
 	void setUp() {
@@ -227,6 +232,9 @@ class DeliveryServiceTest {
 		@Test
 		@DisplayName("성공한다.")
 		void success_test() {
+			// given
+			doNothing().when(orderService).finishOrder(anyLong());
+
 			// when
 			DeliveryHistoryResponse deliveryHistoryResponse = deliveryService.finishDelivery(delivery.getDeliveryId(),
 				rider.getRiderId());
@@ -284,6 +292,7 @@ class DeliveryServiceTest {
 
 		@BeforeEach
 		void setDeliveryHistory() {
+			doNothing().when(orderService).finishOrder(anyLong());
 			deliveryService.allocateRider(delivery.getDeliveryId(), rider.getRiderId());
 			deliveryService.startDelivery(delivery.getDeliveryId(), rider.getRiderId());
 			deliveryService.finishDelivery(delivery.getDeliveryId(), rider.getRiderId());


### PR DESCRIPTION
## PR 확인 항목 
PR 보내기전에 아래 항목들을 만족 하였는지 체크 해주세요 

- [x] 곤모슬 팀에서 정한 커밋 메시지 규칙과 일치하는가?
- [x] 곤모슬 팀에서 정한 코딩 컨벤션과 일치하는가?

## PR 종류
어떤 종류의 PR인지 아래 항목중에 체크 해주세요
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [x] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 변경 (formatting, local variables)
- [ ] 리팩토링 (기능 변경 X)
- [ ] 빌드 관련 수정
- [ ] 문서 내용 수정
- [ ] 테스트 추가
- [ ] 그 외, 어떤 종류인지 기입 바람:


## 어떤 기능이 추가 되었나요?
<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

Issue Number: HIMIN-236


## 기존에 있던 기능에 영향을 주나요?

- [ ] 네
- [ ] 아니요


<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


## 기타
기존에는 Delivery 도메인의 배달 종료 히스토리 저장 이후 트랜잭션을 분리하여 이벤트 처리로 Order에게 배달 완료를 전달했는데,
트랜잭션을 분리할 시 생길 수 있는 문제점이, Order의 배달종료 히스토리 저장에 실패할 경우 Order에는 배달 완료 히스토리가 저장이 되지 않지만,
Delivery 도메인의 배달 종료 히스토리 저장은 다른 트랜잭션이라, Delivery의 배달 종료는 정상 저장되어 데이터의 정합성이 깨지는 문제를 발견하여 Delivery의 배달종료 히스토리 저장 - Order의 배달완료 히스토리 저장을 같은 트랜잭션으로 묶어주었습니다.