### PR TITLE
[NO-ZIRA] refactor : 주문 다건 조회 역할과 책임을 고려하여 리팩토링

### DIFF
--- a/src/main/java/com/prgrms/himin/order/application/OrderService.java
+++ b/src/main/java/com/prgrms/himin/order/application/OrderService.java
@@ -56,14 +56,6 @@ public class OrderService {
 
 	private final MenuValidator menuValidator;
 
-	private static int getLastIndex(List<Order> orders, int size) {
-		if (orders.size() <= size) {
-			return orders.size() - 1;
-		}
-
-		return orders.size() - 2;
-	}
-
 	@Transactional
 	public OrderResponse createOrder(OrderCreateRequest request) {
 		Member member = memberRepository.findById(request.memberId())
@@ -265,37 +257,30 @@ public class OrderService {
 		List<Order> orders = orderRepository.searchOrders(
 			memberId,
 			orderSearchCondition,
-			size,
+			size + 1,
 			cursor
 		);
 
 		return new OrderResponses(
 			getOrderResponses(orders),
 			size,
-			getNextCursor(
-				memberId,
-				orders,
-				size
-			),
+			getNextCursor(orders),
 			isLast(orders, size)
 		);
 	}
 
+	private int getLastIndex(List<Order> orders) {
+		return orders.size() - 1;
+	}
+
 	private Long getNextCursor(
-		Long memberId,
-		List<Order> orders,
-		int size
+		List<Order> orders
 	) {
 		if (orders.isEmpty()) {
-			Order lastOrder = orderRepository.findFirstByMemberIdOrderByOrderIdDesc(memberId);
-			if (lastOrder == null) {
-				return null;
-			}
-
-			return lastOrder.getOrderId();
+			return null;
 		}
 
-		int lastIndex = getLastIndex(orders, size);
+		int lastIndex = getLastIndex(orders);
 		return orders.get(lastIndex).getOrderId();
 	}
 

--- a/src/main/java/com/prgrms/himin/order/domain/OrderRepository.java
+++ b/src/main/java/com/prgrms/himin/order/domain/OrderRepository.java
@@ -3,6 +3,4 @@ package com.prgrms.himin.order.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
-
-	Order findFirstByMemberIdOrderByOrderIdDesc(Long member_id);
 }

--- a/src/main/java/com/prgrms/himin/order/domain/OrderRepositoryImpl.java
+++ b/src/main/java/com/prgrms/himin/order/domain/OrderRepositoryImpl.java
@@ -38,17 +38,17 @@ public class OrderRepositoryImpl implements OrderRepositoryCustom {
 				equalCategory(orderSearchCondition.categories()),
 				equalOrderStatus(orderSearchCondition.orderStatuses()),
 				betweenTime(orderSearchCondition.startTime(), orderSearchCondition.endTime()),
-				greaterThanCursor(cursor)
+				greaterOrEqualThanCursor(cursor)
 			)
 			.leftJoin(orderHistory).on(orderHistory.order.eq(order)) // fetch가 아니라 필터 하기 위한 join
 			.leftJoin(order.orderItems, orderItem)
 			.fetchJoin()
-			.limit(size + 1)
+			.limit(size)
 			.fetch();
 	}
 
-	private Predicate greaterThanCursor(Long cursor) {
-		return cursor != null ? order.orderId.gt(cursor) : null;
+	private Predicate greaterOrEqualThanCursor(Long cursor) {
+		return cursor != null ? order.orderId.goe(cursor) : null;
 	}
 
 	private BooleanExpression betweenTime(LocalDateTime start, LocalDateTime end) {

--- a/src/test/java/com/prgrms/himin/order/application/OrderServiceTest.java
+++ b/src/test/java/com/prgrms/himin/order/application/OrderServiceTest.java
@@ -172,7 +172,7 @@ class OrderServiceTest {
 			assertThat(orderResponses.size()).isEqualTo(pageSize);
 			assertThat(orderResponses.isLast()).isFalse();
 
-			OrderResponse expectedCursorResponse = expectedOrderResponses.get(pageSize - 1);
+			OrderResponse expectedCursorResponse = expectedOrderResponses.get(pageSize);
 			assertThat(orderResponses.nextCursor()).isEqualTo(expectedCursorResponse.orderId());
 
 			int expectedOrderResponsesIdx = 0;


### PR DESCRIPTION
## PR 확인 항목 
PR 보내기전에 아래 항목들을 만족 하였는지 체크 해주세요 

- [x] 곤모슬 팀에서 정한 커밋 메시지 규칙과 일치하는가?
- [x] 곤모슬 팀에서 정한 코딩 컨벤션과 일치하는가?

## PR 종류
어떤 종류의 PR인지 아래 항목중에 체크 해주세요
<!-- 아래 항목중에 올바른 항목에"x"를 추가해주세요 -->

- [ ] 버그 수정
- [ ] 기능 추가
- [ ] 코드 스타일 변경 (formatting, local variables)
- [x] 리팩토링 (기능 변경 X)
- [ ] 빌드 관련 수정
- [ ] 문서 내용 수정
- [ ] 테스트 추가
- [ ] 그 외, 어떤 종류인지 기입 바람:


## 어떤 기능이 추가 되었나요?
<!--어떤 기능이 추가 되었는지 설명해주시고 관련된 지라 이슈 넘버를 추가 해주세요 -->

### 주문 다건 조회 리팩토링
- 주문 서비스는 현재 주문 요청이 마지막인지 확인하고 클라이언트에 반환하는 역할이 있다.
- 주문 서비스에서 size를 요청하면 기존 주문 repository에서 size+1 만큼 반환 하였다.
- 그런데 주문 repository에서 size+1를 하는 것은 repository의 책임이 아니기 때문에서 주문 서비스에서 size+1 만큼 요청하도록 수정 하였다.
- 추가적으로 주문 목록에서 size-2 번째 주문 id를 cursor id로 반환하는 코드가 의미상 파악하기 어려운 문제가 있었다.
- 이를 해결하기 위해 주문 repository에서 cursor id 초과한것을 조회 한것이 아니라 cursor id의 이상을 반환하도록 하여 size-1 번째 cursor id를 반환하도록 수정 하였다.  

Issue Number: NO-ZIRA


## 기존에 있던 기능에 영향을 주나요?

- [ ] 네
- [x] 아니요


<!-- 만약 이번 PR이 기존에 있던 기능을 삭제하거나 영향을 준다면 어떤 곳에 영향을 주는지 구체적으로 설명해주세요 -->


## 기타

